### PR TITLE
feat: add deprecation warnings for Claude Code SDK to Claude Agent SDK migration

### DIFF
--- a/src/claude_code_sdk/client.py
+++ b/src/claude_code_sdk/client.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import warnings
 from collections.abc import AsyncIterable, AsyncIterator
 from dataclasses import replace
 from typing import Any
@@ -53,6 +54,14 @@ class ClaudeSDKClient:
 
     def __init__(self, options: ClaudeCodeOptions | None = None):
         """Initialize Claude SDK client."""
+        warnings.warn(
+            "The Claude Code SDK is now the Claude Agent SDK! "
+            "Please install and use claude-agent-sdk instead. "
+            "See https://docs.claude.com/en/docs/claude-code/sdk/migration-guide for migration instructions.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if options is None:
             options = ClaudeCodeOptions()
         self.options = options

--- a/src/claude_code_sdk/query.py
+++ b/src/claude_code_sdk/query.py
@@ -1,6 +1,7 @@
 """Query function for one-shot interactions with Claude Code."""
 
 import os
+import warnings
 from collections.abc import AsyncIterable, AsyncIterator
 from typing import Any
 
@@ -113,6 +114,14 @@ async def query(
         ```
 
     """
+    warnings.warn(
+        "The Claude Code SDK is now the Claude Agent SDK! "
+        "Please install and use claude-agent-sdk instead. "
+        "See https://docs.claude.com/en/docs/claude-code/sdk/migration-guide for migration instructions.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if options is None:
         options = ClaudeCodeOptions()
 


### PR DESCRIPTION


Add DeprecationWarning to both ClaudeSDKClient and query() entry points to inform users that the package has been renamed to claude-agent-sdk and provide migration guidance.

🤖 Generated with [Claude Code](https://claude.ai/code)