### PR TITLE
Update model references to claude-sonnet-4-5

### DIFF
--- a/e2e-tests/test_include_partial_messages.py
+++ b/e2e-tests/test_include_partial_messages.py
@@ -28,7 +28,7 @@ async def test_include_partial_messages_stream_events():
 
     options = ClaudeAgentOptions(
         include_partial_messages=True,
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-4-5",
         max_turns=2,
         env={
             "MAX_THINKING_TOKENS": "8000",
@@ -94,7 +94,7 @@ async def test_include_partial_messages_thinking_deltas():
 
     options = ClaudeAgentOptions(
         include_partial_messages=True,
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-4-5",
         max_turns=2,
         env={
             "MAX_THINKING_TOKENS": "8000",
@@ -132,7 +132,7 @@ async def test_partial_messages_disabled_by_default():
 
     options = ClaudeAgentOptions(
         # include_partial_messages not set (defaults to False)
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-4-5",
         max_turns=2,
     )
 

--- a/examples/include_partial_messages.py
+++ b/examples/include_partial_messages.py
@@ -29,7 +29,7 @@ async def main():
     # Enable partial message streaming
     options = ClaudeAgentOptions(
         include_partial_messages=True,
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-4-5",
         max_turns=2,
         env={
             "MAX_THINKING_TOKENS": "8000",

--- a/examples/streaming_mode.py
+++ b/examples/streaming_mode.py
@@ -219,7 +219,7 @@ async def example_with_options():
         allowed_tools=["Read", "Write"],  # Allow file operations
         system_prompt="You are a helpful coding assistant.",
         env={
-            "ANTHROPIC_MODEL": "claude-sonnet-4-20250514",
+            "ANTHROPIC_MODEL": "claude-sonnet-4-5",
         },
     )
 

--- a/examples/streaming_mode_trio.py
+++ b/examples/streaming_mode_trio.py
@@ -46,7 +46,7 @@ def display_message(msg):
 async def multi_turn_conversation():
     """Example of a multi-turn conversation using trio."""
     async with ClaudeSDKClient(
-        options=ClaudeAgentOptions(model="claude-3-5-sonnet-20241022")
+        options=ClaudeAgentOptions(model="claude-sonnet-4-5")
     ) as client:
         print("=== Multi-turn Conversation with Trio ===\n")
 

--- a/src/claude_agent_sdk/client.py
+++ b/src/claude_agent_sdk/client.py
@@ -232,7 +232,7 @@ class ClaudeSDKClient:
 
         Args:
             model: The model to use, or None to use default. Examples:
-                - 'claude-sonnet-4-20250514'
+                - 'claude-sonnet-4-5'
                 - 'claude-opus-4-1-20250805'
                 - 'claude-opus-4-20250514'
 
@@ -243,7 +243,7 @@ class ClaudeSDKClient:
                 await client.query("Help me understand this problem")
 
                 # Switch to a different model for implementation
-                await client.set_model('claude-3-5-sonnet-20241022')
+                await client.set_model('claude-sonnet-4-5')
                 await client.query("Now implement the solution")
             ```
         """

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -106,7 +106,7 @@ class TestSubprocessCLITransport:
             options=ClaudeAgentOptions(
                 allowed_tools=["Read", "Write"],
                 disallowed_tools=["Bash"],
-                model="claude-3-5-sonnet",
+                model="claude-sonnet-4-5",
                 permission_mode="acceptEdits",
                 max_turns=5,
             ),
@@ -119,7 +119,7 @@ class TestSubprocessCLITransport:
         assert "--disallowedTools" in cmd
         assert "Bash" in cmd
         assert "--model" in cmd
-        assert "claude-3-5-sonnet" in cmd
+        assert "claude-sonnet-4-5" in cmd
         assert "--permission-mode" in cmd
         assert "acceptEdits" in cmd
         assert "--max-turns" in cmd

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -145,7 +145,7 @@ class TestOptions:
     def test_claude_code_options_with_model_specification(self):
         """Test Options with model specification."""
         options = ClaudeAgentOptions(
-            model="claude-3-5-sonnet-20241022", permission_prompt_tool_name="CustomTool"
+            model="claude-sonnet-4-5", permission_prompt_tool_name="CustomTool"
         )
-        assert options.model == "claude-3-5-sonnet-20241022"
+        assert options.model == "claude-sonnet-4-5"
         assert options.permission_prompt_tool_name == "CustomTool"


### PR DESCRIPTION
Replace all dated model references (claude-sonnet-4-20250514, claude-3-5-sonnet-20241022) with the simplified claude-sonnet-4-5 identifier across examples, tests, and documentation.

🤖 Generated with [Claude Code](https://claude.ai/code)