### PR TITLE
fix(types): export HookJSONOutput in __init__.py

### DIFF
--- a/src/claude_agent_sdk/__init__.py
+++ b/src/claude_agent_sdk/__init__.py
@@ -41,6 +41,7 @@ from .types import (
     ToolResultBlock,
     ToolUseBlock,
     UserMessage,
+    HookJSONOutput
 )
 
 # MCP Server Support
@@ -322,4 +323,6 @@ __all__ = [
     "CLINotFoundError",
     "ProcessError",
     "CLIJSONDecodeError",
+     "HookJSONOutput",
+    
 ]

--- a/src/claude_agent_sdk/__init__.py
+++ b/src/claude_agent_sdk/__init__.py
@@ -324,5 +324,4 @@ __all__ = [
     "ProcessError",
     "CLIJSONDecodeError",
      "HookJSONOutput",
-    
 ]


### PR DESCRIPTION
Expose HookJSONOutput at the package root to fix type-checking errors when implementing hook callbacks. This allows users to import it directly without relying on private modules.