### PR TITLE
Add minimum Claude Code version check (2.0.0+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip install claude-agent-sdk
 **Prerequisites:**
 - Python 3.10+
 - Node.js
-- Claude Code: `npm install -g @anthropic-ai/claude-code`
+- Claude Code 2.0.0+: `npm install -g @anthropic-ai/claude-code`
 
 ## Quick Start
 


### PR DESCRIPTION
- Add version check in subprocess transport that runs `claude -v` on connect
- Display warning to stderr if version is below 2.0.0
- Update README prerequisites to specify Claude Code 2.0.0+
- Version check is non-blocking (warns but continues execution)

🤖 Generated with [Claude Code](https://claude.ai/code)