### PR TITLE
Add Windows support to test workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
@@ -37,10 +38,11 @@ jobs:
           fail_ci_if_error: false
 
   test-e2e:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: test # Run after unit tests pass
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
@@ -51,10 +53,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Claude Code
+      - name: Install Claude Code (Linux)
+        if: runner.os == 'Linux'
         run: |
           curl -fsSL https://claude.ai/install.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install Claude Code (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          irm https://claude.ai/install.ps1 | iex
+        shell: pwsh
 
       - name: Verify Claude Code installation
         run: claude -v
@@ -71,10 +80,11 @@ jobs:
           python -m pytest e2e-tests/ -v -m e2e
 
   test-examples:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: test-e2e # Run after e2e tests
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
@@ -85,10 +95,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Claude Code
+      - name: Install Claude Code (Linux)
+        if: runner.os == 'Linux'
         run: |
           curl -fsSL https://claude.ai/install.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install Claude Code (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          irm https://claude.ai/install.ps1 | iex
+        shell: pwsh
 
       - name: Verify Claude Code installation
         run: claude -v
@@ -98,9 +115,22 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
 
-      - name: Run example scripts
+      - name: Run example scripts (Linux)
+        if: runner.os == 'Linux'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           python examples/quick_start.py
           timeout 120 python examples/streaming_mode.py all
+
+      - name: Run example scripts (Windows)
+        if: runner.os == 'Windows'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python examples/quick_start.py
+          $job = Start-Job { python examples/streaming_mode.py all }
+          Wait-Job $job -Timeout 120 | Out-Null
+          Stop-Job $job
+          Receive-Job $job
+        shell: pwsh


### PR DESCRIPTION
Add cross-platform testing for Windows alongside Linux across all test jobs (unit tests, e2e tests, and examples). Uses native Windows installation via PowerShell script and platform-specific timeout handling for example scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)